### PR TITLE
Update fetch.js to match formatting on Wikipedia

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -72,8 +72,8 @@ async function fetch (wiki_url) {
               recordType = 'Test';
             }
 
-            if (sectionName.indexOf(' - ') !== -1) {
-              let sectionParts = sectionName.split(' - ');
+            if (sectionName.indexOf(' – ') !== -1) {
+              let sectionParts = sectionName.split(' – ');
               countryName = sectionParts[0];
               countryCode = sectionParts[1];
               recordType = 'National';


### PR DESCRIPTION
The '–' char appears to be in use currently rather than '-'.